### PR TITLE
Added error message when zero or more is improperly used.

### DIFF
--- a/src/meander/match/alpha.clj
+++ b/src/meander/match/alpha.clj
@@ -1177,7 +1177,7 @@
     whenever validation succeeds. child-nodes are the child nodes of
     node. new-env is env extended with variables that would be bound
     during the process of matching node but not it's children."
-  {:arglists '([node env])}
+  {:arglists '([node env search?])}
   (fn [[tag] env search?]
     tag)
   :default ::default)
@@ -1218,7 +1218,7 @@
 
 
 (defmethod check-node :rp*
-  [[_ {items :items} :as node] env _]
+  [[_ {items :items, dots :dots} :as node] env _]
   (let [init-cat [:cat items]
         init-vars (r.syntax/variables init-cat)
         unbound-lvrs (into #{} (comp (filter r.syntax/lvr-node?)
@@ -1228,11 +1228,18 @@
       (seq unbound-lvrs)
       [:error [{:message "Zero or more patterns may not have references to unbound logic variables."
                 :ex-data {:unbound (into #{} (map r.syntax/unparse) unbound-lvrs)}}]]
+
       (empty? items)
-      [:error [{:message "Zero or more (...) is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"}]]
-      :else [:okay (r.syntax/children node) env])))
+      (let [dots (if (r.syntax/zero-or-more-symbol? dots)
+                   dots
+                   '...)]
+        [:error
+         [{:message (format "Zero or more (%s) is a postfix operator. It must have some value in front of it. (i.e. [1 %s ?x])"
+                            dots
+                            dots)}]])
 
-
+      :else
+      [:okay (r.syntax/children node) env])))
 
 
 (defmethod check-node :lvr

--- a/src/meander/match/alpha.clj
+++ b/src/meander/match/alpha.clj
@@ -1224,10 +1224,15 @@
         unbound-lvrs (into #{} (comp (filter r.syntax/lvr-node?)
                                      (remove env))
                            init-vars)]
-    (if (seq unbound-lvrs)
+    (cond
+      (seq unbound-lvrs)
       [:error [{:message "Zero or more patterns may not have references to unbound logic variables."
                 :ex-data {:unbound (into #{} (map r.syntax/unparse) unbound-lvrs)}}]]
-      [:okay (r.syntax/children node) env])))
+      (empty? items)
+      [:error [{:message "Zero or more (...) is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"}]]
+      :else [:okay (r.syntax/children node) env])))
+
+
 
 
 (defmethod check-node :lvr

--- a/src/meander/syntax/alpha.clj
+++ b/src/meander/syntax/alpha.clj
@@ -141,7 +141,7 @@
 (defn zero-or-more-symbol?
   [x]
   (and (simple-symbol? x)
-       (re-matches #"\.\.+" (name x))))
+       (re-matches #"\.\.\.+" (name x))))
 
 
 (defn n-or-more-symbol?

--- a/src/meander/syntax/alpha.clj
+++ b/src/meander/syntax/alpha.clj
@@ -141,7 +141,7 @@
 (defn zero-or-more-symbol?
   [x]
   (and (simple-symbol? x)
-       (re-matches #"\.\.\." (name x))))
+       (re-matches #"\.\.+" (name x))))
 
 
 (defn n-or-more-symbol?

--- a/src/meander/syntax/alpha.clj
+++ b/src/meander/syntax/alpha.clj
@@ -141,7 +141,7 @@
 (defn zero-or-more-symbol?
   [x]
   (and (simple-symbol? x)
-       (re-matches #"\.\.+" (name x))))
+       (re-matches #"\.\.\." (name x))))
 
 
 (defn n-or-more-symbol?
@@ -214,7 +214,7 @@
 
 (s/def :meander.syntax.alpha/zero-or-more
   (s/with-gen
-    (s/cat :items (s/+ :meander.syntax.alpha.sequential/subterm)
+    (s/cat :items (s/* :meander.syntax.alpha.sequential/subterm)
            :dots zero-or-more-symbol?)
     (fn []
       (s.gen/fmap

--- a/test/meander/match/alpha_test.clj
+++ b/test/meander/match/alpha_test.clj
@@ -7,8 +7,7 @@
             [clojure.test.check.generators :as tc.gen]
             [clojure.test.check.properties :as tc.prop]
             [meander.match.alpha :as r.match]
-            [meander.syntax.alpha :as r.syntax]
-            [clojure.string :as string]))
+            [meander.syntax.alpha :as r.syntax]))
 
 ;; ---------------------------------------------------------------------
 ;; match macro tests

--- a/test/meander/match/alpha_test.clj
+++ b/test/meander/match/alpha_test.clj
@@ -626,10 +626,10 @@
 (t/deftest no-value-before-zero-or-more
   (t/testing "match"
     (let [error (r.match/check (r.syntax/parse '[... ?x]) false)]
-      (t/is (= "Zero or more ... is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"
+      (t/is (= "Zero or more (...) is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"
                (.getMessage error)))))
 
   (t/testing "search"
     (let [error (r.match/check (r.syntax/parse '[... ?x]) false)]
-      (t/is (= "Zero or more ... is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"
+      (t/is (= "Zero or more (...) is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"
                (.getMessage error))))))

--- a/test/meander/match/alpha_test.clj
+++ b/test/meander/match/alpha_test.clj
@@ -622,16 +622,14 @@
              {:?x 1, :?y 2, :!zs [1 2 3 5 6 7 8 9]}
              {:?x 1, :?y 2, :!zs [3 5 6 7 8 9]}})))
 
-(defmacro catch-macroexpand-error
-  [body]
-  `(try
-     (macroexpand '~body)
-     (catch Exception e# e#)))
 
 (t/deftest no-value-before-zero-or-more
-  (let [error (catch-macroexpand-error
-               (r.match/match [1 2 3]
-                 [... ?x]
-                 [?]))]
-    (t/is (string/includes? (.getMessage error)
-                            "Zero or more (...) is a postfix operator"))))
+  (t/testing "match"
+    (let [error (r.match/check (r.syntax/parse '[... ?x]) false)]
+      (t/is (= "Zero or more ... is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"
+               (.getMessage error)))))
+
+  (t/testing "search"
+    (let [error (r.match/check (r.syntax/parse '[... ?x]) false)]
+      (t/is (= "Zero or more ... is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"
+               (.getMessage error))))))

--- a/test/meander/match/alpha_test.clj
+++ b/test/meander/match/alpha_test.clj
@@ -7,7 +7,8 @@
             [clojure.test.check.generators :as tc.gen]
             [clojure.test.check.properties :as tc.prop]
             [meander.match.alpha :as r.match]
-            [meander.syntax.alpha :as r.syntax]))
+            [meander.syntax.alpha :as r.syntax]
+            [clojure.string :as string]))
 
 ;; ---------------------------------------------------------------------
 ;; match macro tests
@@ -620,3 +621,17 @@
            #{{:?x 1, :?y 2, :!zs [1 2 1 2 3 5 6 7 8 9]}
              {:?x 1, :?y 2, :!zs [1 2 3 5 6 7 8 9]}
              {:?x 1, :?y 2, :!zs [3 5 6 7 8 9]}})))
+
+(defmacro catch-macroexpand-error
+  [body]
+  `(try
+     (macroexpand '~body)
+     (catch Exception e# e#)))
+
+(t/deftest no-value-before-zero-or-more
+  (let [error (catch-macroexpand-error
+               (r.match/match [1 2 3]
+                 [... ?x]
+                 [?]))]
+    (t/is (string/includes? (.getMessage error)
+                            "Zero or more (...) is a postfix operator"))))


### PR DESCRIPTION
Before this change is someone accidentally used zero-or-more improperly `(... ?x)` with no preceding value, there would be invalid macroexpansion. Now users will recieve a much more helpful error message.

There are equivilant problems with one-or-more. But I'd like to also handle the case where a user forgets the number on one-or-more `(1 .. ?x)`. Unfortunately this leaves one bit of ugly code that I'm not sure how to make better. So I will make that a separate commit/PR from this one.