### PR TITLE
Added error cases for rp+

### DIFF
--- a/src/meander/match/alpha.clj
+++ b/src/meander/match/alpha.clj
@@ -1249,12 +1249,15 @@
 (defmethod check-node :rp+
   [[_ {items :items dots :dots} :as node] env _]
   (cond
-    (= (name dots) "..")
-    [:error [{:message "Invalid dot operator. Perhaps you meant the one or more operator (..N) or the zero or more operator (...)?"}]]
+    (= '.. dots)
+    [:error [{:message "Ambiguous ellipsis. Perhaps you meant the n or more operator (..N) or the zero or more operator (...)?"}]]
+
     (empty? items)
-    [:error [{:message (format "One or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 %s ?x])"
+    [:error [{:message (format "N or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 %s ?x])"
                                dots)}]]
-    :else [:okay (r.syntax/children node) env]))
+
+    :else
+    [:okay (r.syntax/children node) env]))
 
 
 (defmethod check-node :lvr

--- a/src/meander/match/alpha.clj
+++ b/src/meander/match/alpha.clj
@@ -1246,6 +1246,17 @@
       [:okay (r.syntax/children node) env])))
 
 
+(defmethod check-node :rp+
+  [[_ {items :items dots :dots} :as node] env _]
+  (cond
+    (= (name dots) "..")
+    [:error [{:message "Invalid dot operator. Perhaps you meant the one or more operator (..N) or the zero or more operator (...)?"}]]
+    (empty? items)
+    [:error [{:message (format "One or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 %s ?x])"
+                               dots)}]]
+    :else [:okay (r.syntax/children node) env]))
+
+
 (defmethod check-node :lvr
   [node env _]
   [:okay [] (conj env node)])

--- a/src/meander/syntax/alpha.clj
+++ b/src/meander/syntax/alpha.clj
@@ -147,7 +147,7 @@
 (defn n-or-more-symbol?
   [x]
   (and (simple-symbol? x)
-       (re-matches #"\.+\d+" (name x))))
+       (re-matches #"\.\.(\d+)?" (name x))))
 
 
 (defn pattern-op-dispatch
@@ -225,7 +225,7 @@
 
 (s/def :meander.syntax.alpha/n-or-more
   (s/with-gen
-    (s/cat :items (s/+ :meander.syntax.alpha.sequential/subterm)
+    (s/cat :items (s/* :meander.syntax.alpha.sequential/subterm)
            :dots n-or-more-symbol?)
     (fn []
       (s.gen/fmap
@@ -1205,9 +1205,11 @@
 
 (defmethod min-length :rp+
   [[_ {items :items, dots :dots}]]
-  (* (count items)
-     (Integer/parseInt
-      (aget (.split (name dots) "\\.+" 2) 1))))
+  (if (= (name dots) "..")
+    0 ;; handle invalid .. operator. Error message will appear later.
+    (* (count items)
+       (Integer/parseInt
+        (aget (.split (name dots) "\\.+" 2) 1)))))
 
 
 (defmethod max-length :rp+

--- a/test/meander/match/alpha_test.clj
+++ b/test/meander/match/alpha_test.clj
@@ -638,3 +638,27 @@
     (let [error (r.match/check (r.syntax/parse '[... ?x]) true)]
       (t/is (= "Zero or more (...) is a postfix operator. It must have some value in front of it. (i.e. [1 ... ?x])"
                (.getMessage error))))))
+
+
+(t/deftest no-value-before-one-or-more
+  (t/testing "match"
+    (let [error (r.match/check (r.syntax/parse '[..2 ?x]) false)]
+      (t/is (= "One or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 ..2 ?x])"
+               (.getMessage error)))))
+
+  (t/testing "search"
+    (let [error (r.match/check (r.syntax/parse '[..2 ?x]) true)]
+      (t/is (= "One or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 ..2 ?x])"
+               (.getMessage error))))))
+
+
+(t/deftest no-value-after-one-or-more
+  (t/testing "match"
+    (let [error (r.match/check (r.syntax/parse '[1 .. ?x]) false)]
+      (t/is (=  "Invalid dot operator. Perhaps you meant the one or more operator (..N) or the zero or more operator (...)?"
+                (.getMessage error)))))
+
+  (t/testing "search"
+    (let [error (r.match/check (r.syntax/parse '[1 .. ?x]) true)]
+      (t/is (= "Invalid dot operator. Perhaps you meant the one or more operator (..N) or the zero or more operator (...)?"
+               (.getMessage error))))))

--- a/test/meander/match/alpha_test.clj
+++ b/test/meander/match/alpha_test.clj
@@ -643,22 +643,22 @@
 (t/deftest no-value-before-one-or-more
   (t/testing "match"
     (let [error (r.match/check (r.syntax/parse '[..2 ?x]) false)]
-      (t/is (= "One or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 ..2 ?x])"
+      (t/is (= "N or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 ..2 ?x])"
                (.getMessage error)))))
 
   (t/testing "search"
     (let [error (r.match/check (r.syntax/parse '[..2 ?x]) true)]
-      (t/is (= "One or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 ..2 ?x])"
+      (t/is (= "N or more (..N) is a postfix operator. It must have some value in front of it. (i.e. [1 ..2 ?x])"
                (.getMessage error))))))
 
 
 (t/deftest no-value-after-one-or-more
   (t/testing "match"
     (let [error (r.match/check (r.syntax/parse '[1 .. ?x]) false)]
-      (t/is (=  "Invalid dot operator. Perhaps you meant the one or more operator (..N) or the zero or more operator (...)?"
+      (t/is (=  "Ambiguous ellipsis. Perhaps you meant the n or more operator (..N) or the zero or more operator (...)?"
                 (.getMessage error)))))
 
   (t/testing "search"
     (let [error (r.match/check (r.syntax/parse '[1 .. ?x]) true)]
-      (t/is (= "Invalid dot operator. Perhaps you meant the one or more operator (..N) or the zero or more operator (...)?"
+      (t/is (= "Ambiguous ellipsis. Perhaps you meant the n or more operator (..N) or the zero or more operator (...)?"
                (.getMessage error))))))


### PR DESCRIPTION
I decided to add two separate error cases under rp+. The first is if
you leave off the prefix that you want to repeat N times `(..2
?x). The second case I've encountered is leaving off the N on
`..N`. In this case, I think the best course of action is to ask the
user if they mean `..N` or `...` as those are easy to typo between.

One unforuntate part of this change was the error handling
`min-length`. If a user leaves off the N, the min-length can't be
taken from the regex of the dots. Unforunately, min-length is called
before check so some change here is necessary. I'm not totally happy with the
solution I have so if you have a better idea, feel free to change it.