### PR TITLE
Add defsyntax macro

### DIFF
--- a/src/meander/syntax/alpha.cljc
+++ b/src/meander/syntax/alpha.cljc
@@ -158,19 +158,6 @@
        (re-matches? #"\.\.(\d+)?" (name x))))
 
 
-(def
-  ^{:dynamic true
-    :private true}
-  *pattern-registry*
-  (atom #{}))
-
-
-(defn pattern-registered?
-  {:private true}
-  [x]
-  (contains? (deref *pattern-registry*) x))
-
-
 (defn expand-symbol
   {:private true}
   [sym]

--- a/src/meander/syntax/alpha.cljc
+++ b/src/meander/syntax/alpha.cljc
@@ -157,13 +157,40 @@
        (re-matches? #"\.\.(\d+)?" (name x))))
 
 
+(def
+  ^{:dynamic true
+    :private true}
+  *pattern-registry*
+  (atom #{}))
+
+
+(defn pattern-registered?
+  {:private true}
+  [x]
+  (contains? (deref *pattern-registry*) x))
+
+
+(defn expand-symbol
+  {:private true}
+  [sym]
+  #?(:clj (if (qualified-symbol? sym)
+            (let [ns-sym (symbol (namespace sym))]
+              (if-some [ns (get (ns-aliases *ns*) ns-sym)]
+                (symbol (name (ns-name ns)) (name sym))
+                nil))
+            (symbol (name (ns-name *ns*)) (name sym)))
+     :cljs sym))
+
+
 (defn pattern-op-dispatch
   "Dispatch function for pattern-op."
   [x]
   (if (seq? x)
     (let [y (first x)]
       (if (symbol? y)
-        y))))
+        (expand-symbol y)
+        nil))
+    nil))
 
 
 (defmulti pattern-op

--- a/src/meander/syntax/alpha.cljc
+++ b/src/meander/syntax/alpha.cljc
@@ -671,6 +671,15 @@
         (subnodes node)))
 
 
+(defn logic-variables
+  "Return all :lvr nodes in node."
+  [node]
+  (s/assert :meander.syntax.alpha/node node)
+  (into #{}
+        (filter (comp #{:lvr} tag))
+        (subnodes node)))
+
+
 (defn memory-variables
   "Return all :mvr nodes in node."
   [node]


### PR DESCRIPTION
This patch allows programmers to extend meander's pattern syntax by extending the parser.

```clj
(defsyntax like [regex]
  `(~'pred
     (fn [x]
       (and (string? x)
            (re-matches? ~regex x)))))
```

`defsyntax` is like `defn` and defines an ordinary function that takes arguments and returns a result as usual. However, it also defines methods for `pattern-op` and `expand-usr-op` with the fully qualified function name (which `pattern-op-dispatch` will now expand). The `pattern-op` definition validates the arguments, and the `expand-usr-op` definition handles passing the arguments to the defined function and calling `parse` recursively on it's result.

Implementation details aside, this should make extending meander's pattern matcher easier. 