### PR TITLE
Relax memory variable occurrence checking in or patterns

### DIFF
--- a/src/meander/match/alpha.cljc
+++ b/src/meander/match/alpha.cljc
@@ -1327,11 +1327,12 @@
 
 (defmethod check-node :dsj
   [[_ {terms :terms} :as node] env _]
-  (let [term-vars (sequence
+  (let [env* (into #{} (remove r.syntax/mvr-node?) env)
+        term-vars (sequence
                    (map
                     (fn [term]
                       ;; We don't need to account for bound variables.
-                      (set/difference (r.syntax/variables term) env)))
+                      (set/difference (r.syntax/logic-variables term) env*)))
                    terms)
         all-vars (reduce set/union #{} term-vars)
         problems (sequence
@@ -1744,7 +1745,6 @@
           nil
           `(let [~target ~expr]
              ~(emit (compile [target] matrix) nil :find)))))))
-
 
 (s/fdef find
   :args (s/cat :expr any?

--- a/src/meander/syntax/alpha.cljc
+++ b/src/meander/syntax/alpha.cljc
@@ -671,6 +671,15 @@
         (subnodes node)))
 
 
+(defn logic-variables
+  "Return all :lvr nodes in node."
+  [node]
+  (s/assert :meander.syntax.alpha/node node)
+  (into #{}
+        (filter (comp #{:lvr} tag))
+        (subnodes node)))
+
+
 (defn memory-variables
   "Return all :mvr nodes in node."
   [node]

--- a/test/meander/match/alpha_test.cljc
+++ b/test/meander/match/alpha_test.cljc
@@ -866,5 +866,14 @@
   (t/is (= [[0 2 4 6 8] [1 3 5 7 9]]
            (r.match/match (range 10)
              ((or (pred even? !evens) (pred odd? !odds)) ...)
-             [!evens !odds]))))
+             [!evens !odds])))
 
+  (t/is (= [[2 1 3] []]
+           (r.match/match [2 1 3]
+             [(or (pred even? !xs) (pred odd? !ys)) !xs !xs]
+             [!xs !ys])))
+
+  (t/is (= [[2 4 6 8] [1 3 5 7 9]]
+           (r.match/match [1 2 3 4 5 6 7 8 9]
+             [(or (pred even? !xs) (pred odd? !ys)) ...]
+             [!xs !ys]))))

--- a/test/meander/match/alpha_test.cljc
+++ b/test/meander/match/alpha_test.cljc
@@ -861,3 +861,10 @@
             ?x)]
     (t/is (or (= x 1)
               (= x 3)))))
+
+(t/deftest unbound-mvrs-in-dsj
+  (t/is (= [[0 2 4 6 8] [1 3 5 7 9]]
+           (r.match/match (range 10)
+             ((or (pred even? !evens) (pred odd? !odds)) ...)
+             [!evens !odds]))))
+


### PR DESCRIPTION
Previously the constraint on or patterns to require all unbound logic variables occur in each clause also applied to memory variables. The constraint on memory variables has been lifted and allows more expressivity in certain contexts.

```clj
((or (pred even? !evens) (pred odd? !odds)) ...)
```
The above pattern will aggregate all `even?` and `odd?` numbers respectively when used with `match` etc.