### PR TITLE
Clojure 1.10 throws a compiler error instead

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.10.0"}
         org.clojure/clojurescript {:mvn/version "1.10.439"}
         org.clojure/test.check {:mvn/version "0.10.0-alpha3"}}
  :aliases {:test {:extra-paths ["test"]

--- a/test/meander/match/delta_test.cljc
+++ b/test/meander/match/delta_test.cljc
@@ -147,7 +147,7 @@
      (t/is (try
              (macroexpand '(meander.match.delta/match 1 (or ?x ?y ?z) false))
              false
-             (catch clojure.lang.ExceptionInfo _
+             (catch Exception _
                true)))))
  
 (tc.t/defspec let-succeeds


### PR DESCRIPTION
fixes #31 