### PR TITLE
Eliminate nth-nodes for wildcard matches in :cat

### DIFF
--- a/src/meander/match/delta.cljc
+++ b/src/meander/match/delta.cljc
@@ -410,11 +410,13 @@
                  nth-syms (take (count elements) nth-syms)
                  targets* `[~@nth-syms ~@targets*]]
              (reduce
-              (fn [tree [i nth-sym]]
-                (r.ir/op-bind nth-sym (r.ir/op-nth (r.ir/op-eval target) i)
-                  tree))
+              (fn [tree [i nth-sym elem]]
+                (case (r.syntax/tag elem)
+                  :any tree
+                  (r.ir/op-bind nth-sym (r.ir/op-nth (r.ir/op-eval target) i)
+                    tree)))
               (compile targets* [(assoc row :cols `[~@elements ~@(:cols row)])])
-              (reverse (map-indexed vector nth-syms)))))))
+              (reverse (map vector (range max-size) nth-syms elements)))))))
      (r.matrix/first-column matrix)
      (r.matrix/drop-column matrix))))
 


### PR DESCRIPTION
This changes eliminates unneeded code generation, by preventing op-nth instructions from being generated for :any (_) values. The difference this makes can be clearly seen by the ir for the follow match expression.

```clojure

(match x
  [_ _ _ _ _] :a)
```

Before this change we'd have the following ir.

```clojure
 {:op :check-vector,
  :then
  {:op :check-bounds,
   :kind :vector,
   :length 5,
   :then
   {:symbol nth_0__28783,
    :value {:index 0, :op :nth, :target {:op :eval, :form target}},
    :op :bind,
    :then
    {:symbol nth_1__28784,
     :value {:index 1, :op :nth, :target {:op :eval, :form target}},
     :op :bind,
     :then
     {:symbol nth_2__28785,
      :value {:index 2, :op :nth, :target {:op :eval, :form target}},
      :op :bind,
      :then
      {:symbol nth_3__28786,
       :value
       {:index 3, :op :nth, :target {:op :eval, :form target}},
       :op :bind,
       :then
       {:symbol nth_4__28787,
        :value
        {:index 4, :op :nth, :target {:op :eval, :form target}},
        :op :bind,
        :then {:value :a, :op :return}}}}}},
   :target {:op :eval, :form target}},
  :target {:op :eval, :form target}}
```

As you can see for each wildcard match an nth instruction is generated that isn't used. After this change, the ir for the match completely eliminates these as shown below.

```clojure
{:op :check-vector,
  :then
  {:op :check-bounds,
   :kind :vector,
   :length 5,
   :then {:value :a, :op :return},
   :target {:op :eval, :form target}},
  :target {:op :eval, :form target}}
```