### PR TITLE
Add the n-times strategy

### DIFF
--- a/src/meander/strategy/delta.cljc
+++ b/src/meander/strategy/delta.cljc
@@ -282,6 +282,21 @@
         t*
         (recur t*)))))
 
+(defn n-times
+  "Builds a strategy that repeats the passed in strategy `n` times.
+  This is particularly useful for non-terminating rewrites or
+  when you are trying to write a strategy and want to make sure you
+  don't accidentally infinite loop.
+
+  ((n-times 2
+   (rewrite
+    ?x (?x ?x)))
+   :x)
+  ;; => ((:x :x) (:x :x))
+  "
+  {:style/indent :defn}
+  [n s]
+  (apply pipe (clojure.core/repeat n s)))
 
 ;; ---------------------------------------------------------------------
 ;; IAll implementation

--- a/test/meander/strategy/delta_test.cljc
+++ b/test/meander/strategy/delta_test.cljc
@@ -379,3 +379,13 @@
     (t/is (= '(s (s (s (s (s 0))))) (fib '(fib (s (s (s (s (s 0)))))))))
     ;; F6 = 8
     (t/is (= '(s (s (s (s (s (s (s (s 0)))))))) (fib '(fib (s (s (s (s (s (s 0))))))))))))
+
+(defn replicate-self [n]
+  (r/n-times n
+    (r/rewrite ?x (?x ?x))))
+
+(t/deftest n-times-test
+  (t/testing "Apply strategy n-times"
+    (t/is (= '(:x :x) ((replicate-self 1) :x)))
+    (t/is (= '((:x :x) (:x :x)) ((replicate-self 2) :x)))
+    (t/is (= '(((:x :x) (:x :x)) ((:x :x) (:x :x))) ((replicate-self 3) :x)))))


### PR DESCRIPTION
Adding a combinator I've found particularly useful. There are times where I want to rewrite things and accidentally cause an infinite loop. This strategy allows me to constrain the repetition to some known upper bound. But even more than that, this is very useful when making things that intentionally don't terminate. Examples are things like `l-systems`. I think it will be even more useful when we create non-deterministic rewrite rules.

I didn't add this to readme yet, because we don't really have a great place for it. It might be a good idea to start thinking about splitting out docs into a more structured area than just the readme so we can describe all of these things.