### PR TITLE
Adds seqable operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,31 @@ Example:
   [(pred even? ?x) (pred odd?)]
   ?x)
 ;; => 42
+
+#### `seqable`
+
+Meander by default matches on specific collection types (sequences, vectors, maps, sets). This operator allows you to match on anything that is seqable.
+
+```clj
+(match [1 2 3]
+  (seqable 1 2 3)
+  :yep)
+;; =>
+:yep
+
+(match '(1 2 3)
+  (seqable 1 2 3)
+  :yep)
+;; =>
+:yep
+
+(match '#{1 2 3}
+  (seqable 1 2 3)
+  :yep)
+;; =>
+:yep
+```
+
 ```
 
 #### `app`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Meander is a Clojure/ClojureScript data transformation library which combines hi
     * [`and`](#and)
     * [`or`](#or)
     * [`pred`](#pred)
+    * [`seqable`](#seqable)
     * [`guard`](#guard)
     * [`app`](#app)
     * [`let`](#let)
@@ -346,6 +347,7 @@ Example:
   [(pred even? ?x) (pred odd?)]
   ?x)
 ;; => 42
+```
 
 #### `seqable`
 
@@ -369,8 +371,6 @@ Meander by default matches on specific collection types (sequences, vectors, map
   :yep)
 ;; =>
 :yep
-```
-
 ```
 
 #### `app`


### PR DESCRIPTION
`seqable` initially grew out of my goal to git rid of the comments on scan and vscan about a useless `seq?` check. scan and vscan coerced things using seq, so really they operate on any seqable.

This is where things started and technically it could stop there. I could have made this a purely internal change. But as I thought more about it, I thought this might be a useful operator.

First, it is has already been implicitly asked for. In slack the question of why meander matches on collection type was asked. I personally agree with the justification given, I think this is the right default for meander. At the same time, meander is made to fit into existing code and often that code will produce various seqable collections and it might be nice to express this fact.

`seqable` can also help us to make these things consistent. We could match with `(seqable !xs ...)` and rewrite into `[!xs ...]`.

I did this work partially to understand the various parts of meander and to see what it would take to add a more significant feature like this. I have tried to test things out and ensure they work, but there could be some corner cases.

I'd definitely love to get some feedback on the idea and/or the implementation of it.