### PR TITLE
Much simpler way to add seqable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Meander is a Clojure/ClojureScript data transformation library which combines hi
     * [`and`](#and)
     * [`or`](#or)
     * [`pred`](#pred)
+    * [`seqable`](#seqable)
     * [`guard`](#guard)
     * [`app`](#app)
     * [`let`](#let)
@@ -346,6 +347,31 @@ Example:
   [(pred even? ?x) (pred odd?)]
   ?x)
 ;; => 42
+```
+
+
+#### `seqable`
+
+Meander by default matches on specific collection types (sequences, vectors, maps, sets). This operator allows you to match on anything that is seqable.
+
+```clj
+(match [1 2 3]
+  (seqable 1 2 3)
+  :yep)
+;; =>
+:yep
+
+(match '(1 2 3)
+  (seqable 1 2 3)
+  :yep)
+;; =>
+:yep
+
+(match '#{1 2 3}
+  (seqable 1 2 3)
+  :yep)
+;; =>
+:yep
 ```
 
 #### `app`

--- a/src/meander/match/epsilon.cljc
+++ b/src/meander/match/epsilon.cljc
@@ -1822,3 +1822,7 @@
       ;; when the target is a vector.
       (~'and (~'not (~'pred vector?))
        (~'pred seqable? (~'app seq (~@inner)))))))
+
+
+(r.match.syntax/defsyntax seqable [& args]
+  `(~'pred seqable? (~'app seq ~args)))

--- a/test/meander/match/epsilon_test.cljc
+++ b/test/meander/match/epsilon_test.cljc
@@ -648,6 +648,134 @@
           _
           false)))
 
+
+
+;; ---------------------------------------------------------------------
+;; seqables
+
+
+(t/deftest basic-seqables
+
+
+  (t/is (r.match/match [1 2 3]
+          (r.match/seqable 1 2 3)
+          true
+          _
+          false))
+
+  (t/is (r.match/match (list 1 2 3)
+          (r.match/seqable 1 2 3)
+          true
+          _
+          false))
+
+  (t/is (r.match/match (range 1 4)
+          (r.match/seqable 1 2 3)
+          true
+          _
+          false))
+
+
+  (t/is (r.match/match [1 2 3]
+          (r.match/seqable ?x ?y ?z)
+          true
+          _
+          false))
+
+  (t/is (r.match/match (list 1 2 3)
+          (r.match/seqable ?x ?y ?z)
+          true
+          _
+          false))
+
+  (t/is (r.match/match #{1 2 3}
+          (r.match/seqable ?x ?y ?z)
+          true
+          _
+          false))
+
+  (t/is (r.match/match #{1 2}
+          (r.match/seqable ?x ?y ?z)
+          false
+          _
+          true))
+
+  (t/is (r.match/match {(list :left) [:right]}
+          (r.match/seqable (r.match/seqable (r.match/seqable ?x) (r.match/seqable ?y)))
+          true
+          _
+          false))
+
+  (t/is (r.match/match [(list :left) [:right]]
+          [(r.match/seqable ?x) (r.match/seqable ?y)]
+          true
+          _
+          false)))
+
+(t/deftest search-seqables
+  (t/is (= 4 (count
+              (r.match/search [[1 2] (list 1 2) #{1 2} {1 2}]
+                (r.match/scan (r.match/seqable ?x ?y))
+                [?x ?y]
+
+                (r.match/scan (r.match/seqable (r.match/seqable ?x ?y)))
+                [?x ?y]))))
+
+  (t/is (= 4 (count
+              (r.match/search {:a [1 2 3]
+                               :b (range 10)
+                               :c #{1 2 3}
+                               :d {:a 1 :b 2}}
+                {?key (r.match/seqable !xs ...)}
+                !xs)))))
+
+
+(defn make-array-list [& args]
+  (java.util.ArrayList. args))
+
+(def ordered-seqable-gen
+  (tc.gen/elements [list vector make-array-list]))
+
+(tc.t/defspec seqable-unquote-patterns-match
+  (tc.prop/for-all [coll ordered-seqable-gen
+                    x gen-scalar
+                    y gen-scalar]
+    (r.match/match (coll x (coll y x) y)
+      (r.match/seqable ~x (r.match/seqable ~y ~x) ~y)
+      true
+
+      _
+      false)))
+
+
+(tc.t/defspec seqable-drop-in-head
+  (tc.prop/for-all [n tc.gen/nat
+                    x gen-scalar]
+    (r.match/match `[~@(map identity (repeat n x)) ~x ~x]
+      (r.match/seqable _ ... ~x ~x)
+      true)))
+
+
+(tc.t/defspec seqable-drop-in-tail
+  (tc.prop/for-all [n tc.gen/nat
+                    x gen-scalar]
+    (r.match/match `[~@(map identity (repeat n x)) ~x ~x]
+      (r.match/seqable~x ~x . _ ...)
+      true)))
+
+
+(tc.t/defspec seqable-mvrs-collect-the-values-they-match
+  (tc.prop/for-all [x gen-scalar
+                    y gen-scalar]
+    (r.match/match [x [y x] y]
+      (r.match/seqable !xs (r.match/seqable !ys !xs) !ys)
+      (and (= [x x] !xs)
+           (= [y y] !ys))
+
+      _
+      false)))
+
+
 ;; ---------------------------------------------------------------------
 ;; re form
 


### PR DESCRIPTION
In [this comment](https://github.com/noprompt/meander/pull/47#issuecomment-501826654) the idea of making seqable using defsyntax was talked about. The only problem was an extra check. Well with fc3f09f32c8b9b43e670add6c5a3487182cce3aa this is no longer the case.

One thing to note is that I did not namespace seqable in the readme. None of the operators have been namespaced there yet and I figure we can do that all at once.