### PR TITLE
 Fixes some disjuncts that would fail

### DIFF
--- a/src/meander/match/syntax/epsilon.cljc
+++ b/src/meander/match/syntax/epsilon.cljc
@@ -82,19 +82,33 @@
                                   (distinct)
                                   (map r.util/case-test-form))
                             a)
-                pred-form (vary-meta `(fn [x#]
-                                        (case x#
-                                          (~@case-tests)
-                                          true
-                                          false))
+
+
+                ;; If we have other arguments, then we should try the
+                ;; rest of our disjuncts if the case-tests fail. If
+                ;; there are no arguments, we should continue matching
+                ;; if we pass the case-tests. That is why we have true
+                ;; and false switched based on b below.
+                pred-form (vary-meta (if (seq b)
+                                       `(fn [x#]
+                                          (case x#
+                                            (~@case-tests)
+                                            false
+                                            true))
+                                       `(fn [x#]
+                                          (case x#
+                                            (~@case-tests)
+                                            true
+                                            false)))
                                      assoc
                                      :meander.match.syntax.epsilon/beta-reduce true)]
-            {:tag ::pred
-             :form pred-form
-             :arguments (if (seq b)
-                          [{:tag ::or
-                            :arguments b}]
-                          [])}))))))
+
+          {:tag ::pred
+           :form pred-form
+           :arguments (if (seq b)
+                        [{:tag ::or
+                          :arguments b}]
+                        [])}))))))
 
 (defn expand-map-rest
   [node]

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -762,6 +762,15 @@
       _
       true)))
 
+(tc.t/defspec or-captures
+  (tc.prop/for-all [x gen-scalar
+                    y gen-scalar
+                    z gen-scalar]
+        (= [[x y z]]
+           (r/match [x y z]
+             (r/or ~z ~y ~x !xs)
+             !xs))))
+
 
 #?(:clj
    ;; If this let appears inside the `deftest` form the test fails for


### PR DESCRIPTION
When trying to capture in an `or` with multiple literals and a lvr i.e. `(or nil 0 !xs)`, you would get a fail if anything other than a nil or a 0 were passed. This happened because of some flipped around conditionals. This fixes that problem. As far as I can tell it doesn't cause any adverse effects.

(Same change was made on delta as well)