### PR TITLE
Fixes some disjuncts that would fail

### DIFF
--- a/src/meander/match/delta.cljc
+++ b/src/meander/match/delta.cljc
@@ -1805,11 +1805,23 @@
                                   (distinct)
                                   (map r.util/case-test-form))
                             a)
-                pred-form `(fn [x#]
-                             (case x#
-                               (~@case-tests)
-                               true
-                               false))]
+
+                ;; If we have other arguments, then we should try the
+                ;; rest of our disjuncts if the case-tests fail. If
+                ;; there are no arguments, we should continue matching
+                ;; if we pass the case-tests. That is why we have true
+                ;; and false switched based on b below.
+                pred-form (if (seq b)
+                            `(fn [x#]
+                               (case x#
+                                 (~@case-tests)
+                                 false
+                                 true))
+                            `(fn [x#]
+                               (case x#
+                                 (~@case-tests)
+                                 true
+                                 false)))]
             {:tag :prd
              :form pred-form
              :arguments (if (seq b)

--- a/test/meander/match/delta_test.cljc
+++ b/test/meander/match/delta_test.cljc
@@ -142,6 +142,17 @@
       _
       true)))
 
+
+
+(tc.t/defspec or-captures
+  (tc.prop/for-all [x gen-scalar
+                     y gen-scalar
+                     z gen-scalar]
+    (= [[x y z]]
+       (r.match/match [x y z]
+         (or ~z ~y ~x !xs)
+         !xs))))
+
 #?(:clj
    (t/deftest or-compilation-fails
      (t/is (try


### PR DESCRIPTION
When trying to capture in an `or` with multiple literals and a lvr i.e. `(or nil 0 !xs)`, you would get a fail if anything other than a nil or a 0 were passed. This happened because of some flipped around conditionals. This fixes that problem. As far as I can tell it doesn't cause any adverse effects.

(same change was made to epsilon)