### PR TITLE
Adds ability to use lvars as keys in maps in match.

### DIFF
--- a/src/meander/match/check/epsilon.cljc
+++ b/src/meander/match/check/epsilon.cljc
@@ -229,9 +229,10 @@
   (if search?
     [:okay (r.syntax/children node) env]
     (let [the-map (:map node)
-          invalid-keys (remove r.syntax/ground? (keys the-map))]
+          value-lvars (set (filter (comp #{:lvr} :tag) (vals the-map)))
+          invalid-keys (remove value-lvars (remove (:lvrs env) (remove r.syntax/ground? (keys the-map))))]
       (if (seq invalid-keys)
-        [:error [{:message "When matching, map patterns may not contain variables in their keys."
+        [:error [{:message "When matching, map patterns may not contain variables in their keys that would make it so there is more than one match possible."
                   :ex-data {:keys (mapv r.syntax/unparse invalid-keys)}}]]
         [:okay (vals the-map) env]))))
 

--- a/test/meander/match/epsilon_test.cljc
+++ b/test/meander/match/epsilon_test.cljc
@@ -23,6 +23,68 @@
     _
     false))
 
+
+(t/deftest matching-and-searching-maps
+  (t/are [x] (if (coll? x)
+               (every? true? x)
+               (true? x))
+    (r/match {:k1 :k2
+              :ks {:k2 {:valid true}}}
+      {:k1 ?k
+       :ks {?k {:valid ?valid}}}
+      ?valid)
+
+    (r/search {:k1 :k2
+              :ks {:k2 {:valid true}}}
+      {:k1 ?k
+       :ks {?k {:valid ?valid}}}
+      ?valid)
+
+    (r/search {1 2
+               3 4
+               :ks {1 {:parent nil}
+                    2 {:parent 1}
+                    3 {:parent nil}
+                    4 {:parent 3}}}
+      {?k1 ?k2
+       :ks {?k2 {:parent ?k1}}}
+      (= 1 (- ?k2 ?k1)))
+
+    (r/match [:a {:a :b}]
+      [?a {?a ?b}]
+      (= ?b :b))
+
+    (r/match {:a :b :b 4 :c 5}
+      {:a ?b ?b (r/pred number?)}
+      (= ?b :b))
+
+    (r/search {2 :a 3 :b}
+      (r/with [%x (r/pred even? ?k)]
+        {%x ?v})
+      (= [2 :a] [?k ?v]))
+
+    (r/search {:a :b :b 4 :c 5}
+      {:a ?b ?b (r/pred number?)}
+      (= ?b :b))
+
+    (r/search {:a :b :b 4 :c 5}
+      {(r/pred keyword?) ?b ?b (r/pred number?)}
+      (= ?b :b))
+
+    (r/search {:a :b :b 4 :c :d :d 6 :e 5}
+      {(r/pred keyword?) ?b ?b (r/pred even? ?num)}
+      (boolean (and (#{:b :d} ?b)
+                    (#{4 6} ?num))))
+
+    (r/search {1 {2 [1 2 3 0]}
+               3 {[1 2 3 0] 4}
+               5 {[1 2 3 0] 6}}
+      {?k1 {?k2 (r/scan 0)}
+       ?k3 {(r/scan 0) ?k4}}
+      (= -2 (- ?k4 ?k3 ?k2 ?k1)))))
+
+
+
 #_
 ;; TODO: This should pass because ?x and ?y can be matched before
 ;; attempting to match the subsequence.
@@ -41,4 +103,3 @@
 
           _
           false)))
-

--- a/test/meander/match/epsilon_test.cljc
+++ b/test/meander/match/epsilon_test.cljc
@@ -11,9 +11,7 @@
 ;; ---------------------------------------------------------------------
 ;; match macro tests
 
-#_
-;; TODO: This should pass because ?x in the nested map can be bound
-;; previously.
+
 (t/deftest map-can-have-variable-bound-lvr-keys
   (r.match/match {:k1 "v1"
                   :k2 {"v1" "v2"}}


### PR DESCRIPTION
There are times when using an lvar as a key is perfectly acceptable. This allows those cases to work in maps. From everything I could think of or try I could not find one where this broke. There are I'm sure cases where this should be allowed but currently are not. But I think in most of those cases, meander wouldn't handle them properly as is.

*matching* is maybe not the greatest name and I'm happy to change it to something else. But I think this is an important property to know in matrix compilation. Match should never using any of our runtime functions. In this case by knowing that we were matching I was able to take something from a linear look up to a constant time lookup. This is a huge improvement and I think shows the need for having this during that step in the process.

I uncommented one test, I am happy to add more or make any suggested changes.