### PR TITLE
Fixes build problems with clojurescript.

### DIFF
--- a/src/meander/epsilon.cljc
+++ b/src/meander/epsilon.cljc
@@ -57,13 +57,14 @@
   For operators which relax this restriction, see `find` and `search`."
   {:arglists '([x & clauses])
    :style/indent :defn}
-  [& args] `(r.match/match ~@args))
+  [& args] `(meander.match.epsilon/match ~@args))
+
 
 (defmacro find
   "Like `search` but returns only the first successful match."
   {:arglists '([x & clauses])
    :style/indent :defn}
-  [& args] `(r.match/find ~@args))
+  [& args] `(meander.match.epsilon/find ~@args))
 
 (defmacro search
   "Like `match` but allows for patterns which may match `x` in more
@@ -91,7 +92,7 @@
       (find x ,,,)"
   {:arglists '([x & clauses])
    :style/indent :defn}
-  [& args] `(r.match/search ~@args))
+  [& args] `(meander.match.epsilon/search ~@args))
 
 (defmacro breadth-first-search
   "Like `search` but traverses the search space in breadth first
@@ -99,7 +100,7 @@
   {:arglists '([x & clauses])
    :style/indent :defn}
   [& args]
-  (with-meta `(r.match/search ~@args)
+  (with-meta `(meander.match.epsilon/search ~@args)
     (assoc (meta &form) :search-order :breadth-first)))
 
 ;; ---------------------------------------------------------------------
@@ -134,7 +135,7 @@
          p_n-1 (subst p_n))"
   {:style/indent :defn}
   [x & clauses]
-  (r.match/match (compile-rewrite [x clauses])
+  (meander.match.epsilon/match (compile-rewrite [x clauses])
     [:error ?error-message]
     (throw (ex-info ?error-message {}))
 
@@ -152,7 +153,7 @@
   compile-rewrites
   (r/rewrite
    [?x (!match !substitution ...)]
-   (`r.match/search ?x . !match (`r.subst/substitute !substitution) ...)
+   (`meander.match.epsilon/search ?x . !match (`r.subst/substitute !substitution) ...)
 
    _
    [:error "rewrite expects and odd number of arguments"]))
@@ -160,7 +161,7 @@
 (defmacro rewrites
   {:style/indent :defn}
   [x & clauses]
-  (r.match/match (compile-rewrites [x clauses])
+  (meander.match.epsilon/match (compile-rewrites [x clauses])
     [:error ?error-message]
     (throw (ex-info ?error-message {}))
 
@@ -240,11 +241,11 @@
   ([binding-patterns]
    (case (::r.syntax/phase &env)
      :meander/match
-     (r.match/match binding-patterns
+     (meander.match.epsilon/match binding-patterns
        [_ _ ...]
        (reduce
         (fn [?inner [?pattern ?expression]]
-          (subst (`r.match.syntax/let ?pattern ?expression ?inner)))
+          (`subst (`r.match.syntax/let ?pattern ?expression ?inner)))
         '_
         (reverse (partition 2 binding-patterns)))
 
@@ -257,11 +258,11 @@
   ([binding-patterns target-pattern]
    (case (::r.syntax/phase &env)
      :meander/match
-     (r.match/match binding-patterns
+     (meander.match.epsilon/match binding-patterns
        [_ _ ...]
        (reduce
         (fn [?inner [?pattern ?expression]]
-          (subst (`r.match.syntax/let ?pattern ?expression ?inner)))
+          (`subst (`r.match.syntax/let ?pattern ?expression ?inner)))
         target-pattern
         (reverse (partition 2 binding-patterns)))
 

--- a/src/meander/syntax/epsilon.cljc
+++ b/src/meander/syntax/epsilon.cljc
@@ -1853,10 +1853,12 @@
          (try
            (require (:name cljs-ns))
            (catch Exception _
-             (doseq [[alias ns-name] (:requires cljs-ns)]
-               (if (= alias ns-name)
-                 (require ns-name)
-                 (require [ns-name :as alias])))))))
+             (try
+               (doseq [[alias ns-name] (:requires cljs-ns)]
+                 (if (= alias ns-name)
+                   (require ns-name)
+                   (require [ns-name :as alias])))
+               (catch Exception _))))))
     `(do ~expander-definition-body-form
          (var ~fn-name))))
 


### PR DESCRIPTION
Some of these fixes I admit to not fully understand what was wrong with them before. But I know it has to do with resolution in macros.

Overall I did three things. Add the catch on importing so we don't throw when trying to import clojurescript modules in clojure. Change how symbols were referred to in macros and normalize out protocol/interface names across clojure and clojurescript. That last one I could come up with better names or take a different approach, if you have opinions I'm happy to change things. This does work and has been tested in my boostratpped clojurescript project that I will hopefully have at a state of working soon.