### PR TITLE
Setup CI using github actions

### DIFF
--- a/.github/workflows/meander.yml
+++ b/.github/workflows/meander.yml
@@ -1,0 +1,28 @@
+name: Meander CI
+
+on: [push]
+
+jobs:
+  clojure:
+
+    runs-on: ubuntu-latest
+    
+    container:
+      image:  clojure:openjdk-11-tools-deps
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run tests
+      run: clj -A:test
+
+  clojurescript:
+
+    runs-on: ubuntu-latest
+    
+    container:
+      image: theasp/clojurescript-nodejs:latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run tests
+      run: clojure -A:cljs-test


### PR DESCRIPTION
I don't know if you've signed up for the github actions beta. But this works over on my fork. We can now have CI for both the clojure and clojurescript tests.


See the run of it here https://github.com/jimmyhmiller/meander/commit/014711b24a3242c7629a9b7d5f1347031b5075d3/checks