### PR TITLE
Improves performance for nth and repeats of width 1.

### DIFF
--- a/src/meander/match/runtime/epsilon.cljc
+++ b/src/meander/match/runtime/epsilon.cljc
@@ -23,6 +23,22 @@
   [x]
   (identical? x FAIL))
 
+(defn run-star-1
+  {:style/indent :defn}
+  [coll rets body-f then-f]
+  (let [result
+        (reduce (fn [acc xs]
+                  (let [acc (body-f acc [xs])]
+                    (if (fail? rets)
+                      (reduced FAIL)
+                      acc)))
+                rets
+                coll)]
+    (if (fail? result)
+      FAIL
+      (then-f result))))
+
+
 (defn run-star-seq
   {:style/indent :defn}
   [coll rets n body-f then-f]


### PR DESCRIPTION
For matches like this one:

```
(m/match coll
    [(m/pred number? !xs) ...]
    !xs)
```

Reduces run time to 50%. If we used transients, we could get this to be performance parity with handwritten clojure.

`nth` was improved only for vectors, but I also added type information for :star nodes. Probably could do the same for plus nodes.