### PR TITLE
Fixes #94: scan with :as clause will never match

### DIFF
--- a/src/meander/epsilon.clj
+++ b/src/meander/epsilon.clj
@@ -334,10 +334,9 @@
   [& patterns]
   (case (::r.syntax/phase &env)
     :meander/match
-    (clj/let [patternc (count patterns)
-              [as as-pattern] (drop (- patternc 2) patterns)
+    (clj/let [[as-pattern as & not-as] (reverse patterns)
               inner (if (= :as as)
-                      `(~@'(_ ...) ~@patterns ~@'(. _ ...) :as ~as-pattern)
+                      `(~@'(_ ...) ~@(reverse not-as) ~@'(. _ ...) :as ~as-pattern)
                       `(~@'(_ ...) ~@patterns ~@'(. _ ...)))]
       `(seqable ~@inner)
       ;; Using `or` like this can cause code explosions. Come back to this

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -1873,6 +1873,20 @@
 
 
 (t/deftest scan-test
+  (t/testing "Given a match anything pattern"
+    (t/is (= '(1 2 3)
+             (r/search [1 2 3]
+                       (r/scan ?x)
+                       ?x))
+          "every element should be found by the scan"))
+
+  (t/testing "Given an :as clause in a match anything scan"
+    (t/is (= '(1 2 3)
+             (r/search [1 2 3]
+                       (r/scan ?x :as ?v)
+                       ?x))
+          "every element should be found by the scan"))
+
   (t/is (= '([:_1 "_1"] [:_2 "_2"] [:_3 "_3"] [:_4 "_4"])
            (r/search [{:_1 "_1"} {:_2 "_2", :_3 "_3"} {:_4 "_4"}]
              (r/scan {?k ?v})


### PR DESCRIPTION
When an as clause is detected, the as clause should not be included in
the patterns.