### PR TITLE
Remove provided & test dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.10.0"}
-        org.clojure/clojurescript {:mvn/version "1.10.439"}
-        org.clojure/test.check {:mvn/version "0.10.0-alpha3"}}
+ :deps {}
  :aliases {:dev {:extra-deps {fipp/fipp {:mvn/version "0.6.21"}}}
            :test {:extra-paths ["test"]
                   :extra-deps {org.clojure/test.check {:mvn/version "0.10.0-alpha3"}


### PR DESCRIPTION
test.check is not used in any runtime code and would best be kept as a test level dependency. Clojure & Clojurescript should be provided by the runtime environment so there isn't a reason to have them in the `:deps`. Clojurescript is a large dep that is best not brought into production Clojure projects. 

These can be removed by exclusions. It'd be nice to have the deps be nice and clean by default though. 