### PR TITLE
Add map-of and submap-of operators

### DIFF
--- a/src/meander/epsilon.clj
+++ b/src/meander/epsilon.clj
@@ -884,16 +884,17 @@
   When used as a pattern substitution operator constructs a map of
   by which all entries are constructed with keys with `k-pattern` and
   values with `v-pattern`."
-  [k-pattern v-pattern]
-  (cond
-    (match-syntax? &env)
-    `(with [%map# (or {~k-pattern ~v-pattern & %map#}
-                      {_# _# & %map#}
-                     '{})]
-       %map#)
+  ([k-pattern v-pattern]
+   (cond
+     (match-syntax? &env)
+     `(with [%map# (or {~k-pattern ~v-pattern & %map#}
+                       {_# _# & %map#}
+                       '{})]
+        %map#)
 
-    (subst-syntax? &env)
-    `{& [[~k-pattern ~v-pattern] ...]}
+     (subst-syntax? &env)
+     `{& [[~k-pattern ~v-pattern] ...]}
 
-    :else
-    &form))
+     :else
+     &form)))
+

--- a/src/meander/epsilon.clj
+++ b/src/meander/epsilon.clj
@@ -850,3 +850,26 @@
 
      :else
      &form)))
+
+(defsyntax map-of
+  "Pattern matching operator which matches a map of which all then
+  entries have keys which match `k-pattern` and all the values match
+  `v-pattern`."
+  [k-pattern v-pattern]
+  (if (match-syntax? &env)
+    `(with [%map# (or {~k-pattern ~v-pattern & %map#}
+                     '{})]
+       %map#)
+    &form))
+
+(defsyntax submap-of
+  "Pattern matching operator which matches a map of which some or none
+  of the entries have keys that match `k-pattern` and values which
+  match `v-pattern`."
+  [k-pattern v-pattern]
+  (if (match-syntax? &env)
+    `(with [%map# (or {~k-pattern ~v-pattern & %map#}
+                      {_# _# & %map#}
+                     '{})]
+       %map#)
+    &form))

--- a/src/meander/epsilon.clj
+++ b/src/meander/epsilon.clj
@@ -852,9 +852,15 @@
      &form)))
 
 (defsyntax map-of
-  "Pattern matching operator which matches a map of which all then
-  entries have keys which match `k-pattern` and all the values match
-  `v-pattern`."
+  "Pattern matching and substitution operator.
+
+  When used as a pattern matching operator matches a map of which all
+  then entries have keys which match `k-pattern` and all the values
+  match `v-pattern`.
+
+  When used as a pattern substitution operator constructs a map of
+  by which all entries are constructed with keys with `k-pattern` and
+  values with `v-pattern`."
   [k-pattern v-pattern]
   (cond
     (match-syntax? &env)
@@ -869,13 +875,25 @@
     &form))
 
 (defsyntax submap-of
-  "Pattern matching operator which matches a map of which some or none
-  of the entries have keys that match `k-pattern` and values which
-  match `v-pattern`."
+  "Pattern matching and substitution operator.
+
+  When used as a pattern matching operator matches a map of which some
+  or none of the entries have keys that match `k-pattern` and values
+  which match `v-pattern`.
+
+  When used as a pattern substitution operator constructs a map of
+  by which all entries are constructed with keys with `k-pattern` and
+  values with `v-pattern`."
   [k-pattern v-pattern]
-  (if (match-syntax? &env)
+  (cond
+    (match-syntax? &env)
     `(with [%map# (or {~k-pattern ~v-pattern & %map#}
                       {_# _# & %map#}
                      '{})]
        %map#)
+
+    (subst-syntax? &env)
+    `{& [[~k-pattern ~v-pattern] ...]}
+
+    :else
     &form))

--- a/src/meander/epsilon.clj
+++ b/src/meander/epsilon.clj
@@ -856,10 +856,16 @@
   entries have keys which match `k-pattern` and all the values match
   `v-pattern`."
   [k-pattern v-pattern]
-  (if (match-syntax? &env)
+  (cond
+    (match-syntax? &env)
     `(with [%map# (or {~k-pattern ~v-pattern & %map#}
                      '{})]
        %map#)
+
+    (subst-syntax? &env)
+    `{& [[~k-pattern ~v-pattern] ...]}
+
+    :else
     &form))
 
 (defsyntax submap-of

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -2437,3 +2437,41 @@
              [!n (!a !b ...)]
              {& [[!a !b] ..!n]})
            {0 1, 2 3, 4 5, 6 7})))
+
+
+(t/deftest map-of-test
+  (t/is (= (r/find {"foo" "bar", "baz" "quux"}
+             (r/map-of (r/pred string? !k) !v)
+             [!k !v])
+          [["baz" "foo"] ["quux" "bar"]]))
+
+  (t/is (= (r/find {:foo "bar", :baz "quux"}
+             (r/map-of (r/pred string? !k) !v)
+             [!k !v])
+          nil))
+
+  (t/is (= (r/find {"foo" "bar", :baz "quux"}
+             (r/map-of (r/pred string? !k) !v)
+             [!k !v])
+          nil)))
+
+(t/deftest submap-of-test
+  (t/is (= (r/find {}
+             (r/submap-of (r/pred string? !k) !v)
+             [!k !v])
+          [[] []]))
+
+  (t/is (= (r/find {"foo" "bar", "baz" "quux"}
+             (r/submap-of (r/pred string? !k) !v)
+             [!k !v])
+          [["baz" "foo"] ["quux" "bar"]]))
+
+  (t/is (= (r/find {:foo "bar", :baz "quux"}
+             (r/submap-of (r/pred string? !k) !v)
+             [!k !v])
+          [[] []]))
+
+  (t/is (= (r/find {"foo" "bar", :baz "quux"}
+             (r/submap-of (r/pred string? !k) !v)
+             [!k !v])
+          [["foo"] ["bar"]])))

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -2455,6 +2455,11 @@
              (r/map-of (r/pred string? !k) !v)
              #{!k !v})))
 
+  (t/is (= {}
+          (let [!k []
+                !v []]
+            (r/subst (r/map-of !k !v)))))
+
   (t/is (= {"foo" 1, "bar" 2}
           (let [!k ["foo" "bar"]
                 !v [1 2]]
@@ -2479,4 +2484,13 @@
   (t/is (= #{["foo"] ["bar"]}
           (set (r/find {"foo" "bar", :baz "quux"}
                   (r/submap-of (r/pred string? !k) !v)
-                  [!k !v])))))
+                  [!k !v]))))
+  (t/is (= {}
+          (let [!k []
+                !v []]
+            (r/subst (r/submap-of !k !v)))))
+
+  (t/is (= {"foo" 1, "bar" 2}
+          (let [!k ["foo" "bar"]
+                !v [1 2]]
+            (r/subst (r/submap-of !k !v))))))

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -2453,7 +2453,12 @@
   (t/is (= (r/find {"foo" "bar", :baz "quux"}
              (r/map-of (r/pred string? !k) !v)
              #{!k !v})
-          nil)))
+          nil))
+
+  (t/is (= (let [!k ["foo" "bar"]
+                 ?v true]
+             (r/subst (r/map-of !k !v)))
+          {"foo" 1, "bar" 2})))
 
 (t/deftest submap-of-test
   (t/is (= (r/find {}

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -2442,17 +2442,17 @@
 (t/deftest map-of-test
   (t/is (= (r/find {"foo" "bar", "baz" "quux"}
              (r/map-of (r/pred string? !k) !v)
-             [!k !v])
-          [["baz" "foo"] ["quux" "bar"]]))
+             #{(set !k) (set !v)})
+          #{#{"baz" "foo"} #{"quux" "bar"}}))
 
   (t/is (= (r/find {:foo "bar", :baz "quux"}
              (r/map-of (r/pred string? !k) !v)
-             [!k !v])
+             #{!k !v})
           nil))
 
   (t/is (= (r/find {"foo" "bar", :baz "quux"}
              (r/map-of (r/pred string? !k) !v)
-             [!k !v])
+             #{!k !v})
           nil)))
 
 (t/deftest submap-of-test
@@ -2461,17 +2461,17 @@
              [!k !v])
           [[] []]))
 
-  (t/is (= (r/find {"foo" "bar", "baz" "quux"}
-             (r/submap-of (r/pred string? !k) !v)
-             [!k !v])
-          [["baz" "foo"] ["quux" "bar"]]))
+  (t/is (= (set (r/find {"foo" "bar", "baz" "quux"}
+                  (r/submap-of (r/pred string? !k) !v)
+                  #{(set !k) (set !v)}))
+          #{#{"baz" "foo"} #{"quux" "bar"}}))
 
   (t/is (= (r/find {:foo "bar", :baz "quux"}
              (r/submap-of (r/pred string? !k) !v)
              [!k !v])
           [[] []]))
 
-  (t/is (= (r/find {"foo" "bar", :baz "quux"}
-             (r/submap-of (r/pred string? !k) !v)
-             [!k !v])
-          [["foo"] ["bar"]])))
+  (t/is (= (set (r/find {"foo" "bar", :baz "quux"}
+                  (r/submap-of (r/pred string? !k) !v)
+                  [!k !v]))
+          #{["foo"] ["bar"]})))

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -2440,43 +2440,43 @@
 
 
 (t/deftest map-of-test
-  (t/is (= (r/find {"foo" "bar", "baz" "quux"}
+  (t/is (= #{#{"baz" "foo"} #{"quux" "bar"}}
+          (r/find {"foo" "bar", "baz" "quux"}
              (r/map-of (r/pred string? !k) !v)
-             #{(set !k) (set !v)})
-          #{#{"baz" "foo"} #{"quux" "bar"}}))
+             #{(set !k) (set !v)})))
 
-  (t/is (= (r/find {:foo "bar", :baz "quux"}
+  (t/is (= nil
+          (r/find {:foo "bar", :baz "quux"}
              (r/map-of (r/pred string? !k) !v)
-             #{!k !v})
-          nil))
+             #{!k !v})))
 
-  (t/is (= (r/find {"foo" "bar", :baz "quux"}
+  (t/is (= nil
+          (r/find {"foo" "bar", :baz "quux"}
              (r/map-of (r/pred string? !k) !v)
-             #{!k !v})
-          nil))
+             #{!k !v})))
 
-  (t/is (= (let [!k ["foo" "bar"]
-                 ?v true]
-             (r/subst (r/map-of !k !v)))
-          {"foo" 1, "bar" 2})))
+  (t/is (= {"foo" 1, "bar" 2}
+          (let [!k ["foo" "bar"]
+                !v [1 2]]
+             (r/subst (r/map-of !k !v))))))
 
 (t/deftest submap-of-test
-  (t/is (= (r/find {}
+  (t/is (= [[] []]
+          (r/find {}
              (r/submap-of (r/pred string? !k) !v)
-             [!k !v])
-          [[] []]))
+             [!k !v])))
 
-  (t/is (= (set (r/find {"foo" "bar", "baz" "quux"}
+  (t/is (= #{#{"baz" "foo"} #{"quux" "bar"}}
+          (set (r/find {"foo" "bar", "baz" "quux"}
                   (r/submap-of (r/pred string? !k) !v)
-                  #{(set !k) (set !v)}))
-          #{#{"baz" "foo"} #{"quux" "bar"}}))
+                  #{(set !k) (set !v)}))))
 
-  (t/is (= (r/find {:foo "bar", :baz "quux"}
+  (t/is (= [[] []]
+          (r/find {:foo "bar", :baz "quux"}
              (r/submap-of (r/pred string? !k) !v)
-             [!k !v])
-          [[] []]))
+             [!k !v])))
 
-  (t/is (= (set (r/find {"foo" "bar", :baz "quux"}
+  (t/is (= #{["foo"] ["bar"]}
+          (set (r/find {"foo" "bar", :baz "quux"}
                   (r/submap-of (r/pred string? !k) !v)
-                  [!k !v]))
-          #{["foo"] ["bar"]})))
+                  [!k !v])))))


### PR DESCRIPTION
This patch adds two operators: `map-of` and `submap-of`.

`map-of` matches a map of which all then entries have keys which match `k-pattern` and all the values match `v-pattern`.

`submap-of` matches a map of which some or none of the entries have keys that match `k-pattern` and values which match `v-pattern`. In other words, all maps.