### PR TITLE
[doc] Clarify $ and add cookbook alternative for replace all

### DIFF
--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -105,3 +105,16 @@ When you have a match pattern that contains a memory varible `!n` and a substitu
   [[!k !n (me/app str !n2)] ...])
 ;; => [[:a 1 "1"] [:b 2 "2"] [:c 3 "3"]]
 ```
+
+## Replace all occurrences
+
+You can use `meander.strategy.epsilon/top-down` or `bottom-up` to find and replace.
+```clojure
+(def p
+  (s/top-down
+    (s/match
+      (m/pred string? ?s) (keyword ?s)
+      ?x ?x)))
+(p [1 ["a" 2] "b" 3 "c"])
+;; => [1 [:a 2] :b 3 :c]
+```

--- a/doc/operator-overview.md
+++ b/doc/operator-overview.md
@@ -21,6 +21,7 @@
     * [`let`](#let)
     * [`not`](#not)
     * [`scan`](#scan)
+    * [`$`](#$)
     * [`with`](#with)
   * [Subsequences](#subsequences)
     * [Zero or More](#zero-or-more)
@@ -491,13 +492,15 @@ recursively searches for any subtree that matches `pattern`.
 ;; => ([[3 4] 5] [3 4])
 ```
 
-Additionally, you can optionally specify a `context` variable that, when called with an argument, returns the toplevel collection with all matched variables replaced with the argument.
+You can optionally specify a `?context` variable that,
+when called with an argument, returns the toplevel collection with the
+matched variable replaced with the argument.
 
 ```clj
 (m/search [[1] 2 [[3 4] 5]]
-  (m/$ ?context [?a ?b])
-  (?context [9])
-;; => ([[1] 2 [9]] [[1] 2 [[9] 5]])
+          (m/$ ?context [?a ?b])
+          (?context (str "a:" ?a ", b:" ?b)))
+;; => ([[1] 2 "a:[3 4], b:5"] [[1] 2 ["a:3, b:4" 5]])
 ```
 
 ### `with`

--- a/doc/operator-overview.md
+++ b/doc/operator-overview.md
@@ -21,7 +21,7 @@
     * [`let`](#let)
     * [`not`](#not)
     * [`scan`](#scan)
-    * [`$`](#$)
+    * [`$`](#subtree-search-)
     * [`with`](#with)
   * [Subsequences](#subsequences)
     * [Zero or More](#zero-or-more)
@@ -476,7 +476,7 @@ searches a sequence for elements that match `pattern`.
 ;; => ({1 :x} {2 :y} {3 :z})
 ```
 
-### `$`
+### Subtree search `$`
 
 ```clj
 (meander.epsilon/$ pattern)


### PR DESCRIPTION
* adds to contents with link
* Fixes incorrect "replace all"
* Provides "replace all" via `top-down`