### PR TITLE
[epsilon] Make seqable suitable for substitution

### DIFF
--- a/src/meander/epsilon.clj
+++ b/src/meander/epsilon.clj
@@ -342,6 +342,9 @@
     :meander/match
     `(r.match.syntax/pred seqable? (r.match.syntax/apply seq ~patterns))
 
+    :meander/substitute
+    patterns
+
     ;; else
     &form))
 

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -1248,7 +1248,12 @@
           [(r/seqable ?x) (r/seqable ?y)]
           true
           _
-          false)))
+          false))
+
+  (t/is (= '(1 2 3 4)
+          (r/rewrite [1 2 3 4]
+            (r/seqable !k ...)
+            (r/seqable !k ...)))))
 
 
 (t/deftest search-seqables


### PR DESCRIPTION
pattern `(seqable !k ...)` is substituted as `(!k ...)`