### PR TITLE
Drop negation? and strategy check during set compilation

### DIFF
--- a/src/meander/match/epsilon.cljc
+++ b/src/meander/match/epsilon.cljc
@@ -1447,11 +1447,8 @@
                                 ir-search-body (r.ir/op-bind elements_target (r.ir/op-nth (r.ir/op-eval search_space_element) 0)
                                                  (r.ir/op-bind rest_target (r.ir/op-nth (r.ir/op-eval search_space_element) 1)
                                                    ir-body))]
-                            (if (or (negating?) (= strategy :find))
-                              (r.ir/op-find search_space_element ir-search-space
-                                ir-search-body)
-                              (r.ir/op-search search_space_element ir-search-space
-                                ir-search-body))))
+                            (r.ir/op-search search_space_element ir-search-space
+                              ir-search-body)))
                      ir (case n
                           0 ir
 

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -2559,3 +2559,7 @@
                                      :b2 (r/or (r/and nil ?b2)
                                                ?b2)})})
                   {:a ?a :b1 ?b1 :b2 ?b2})))))
+
+(t/deftest gh-143
+  (let [x #{{:a 1} {:a 2} {:a 3}}]
+    (t/is (= x (set (r/search x #{{:as ?it}} ?it))))))


### PR DESCRIPTION
This is no longer needed as negation was improved a couple months ago and the `negating?` check is no longer needed.