### PR TITLE
Address all reflection warnings

### DIFF
--- a/src/meander/match/epsilon.cljc
+++ b/src/meander/match/epsilon.cljc
@@ -232,6 +232,8 @@
 
 
 (def ^{:doc "Node tags ordered from highest precedence to lowest."
+       :tag #?(:clj clojure.lang.PersistentVector
+               :cljs nil)
        :private true}
   tag-ranking
   [:mut

--- a/src/meander/matrix/epsilon.cljc
+++ b/src/meander/matrix/epsilon.cljc
@@ -161,7 +161,9 @@
   [f matrix]
   (if (empty? matrix)
     {}
-    (let [matrix (vec matrix)
+    (let [#?(:clj  ^clojure.lang.PersistentVector matrix
+             :cljs matrix)
+          (vec matrix)
           grouped (group-by (comp f first :cols) matrix)]
       (into
        (sorted-map-by

--- a/src/meander/substitute/runtime/epsilon.cljc
+++ b/src/meander/substitute/runtime/epsilon.cljc
@@ -11,9 +11,10 @@
   #?(:clj
      (if (instance? java.lang.Iterable coll)
        (.iterator ^java.lang.Iterable coll)
-       (if (nil? coll)
-         (.iterator ^java.lang.Iterable ())
-         (.iterator ^java.lang.Iterable (seq coll))))
+       (let [^java.lang.Iterable v (if (nil? coll)
+                                     ()
+                                     (seq coll))]
+         (.iterator v)))
 
      :cljs
      (iter coll)))

--- a/src/meander/util/epsilon.cljc
+++ b/src/meander/util/epsilon.cljc
@@ -428,7 +428,8 @@
   ;;     [[\"a\"] [\"b\"] []]
   ;;     [[\"ab\"] [] []])
   "
-  [n str]
+  [n #?(:clj  ^String str
+        :cljs str)]
   {:pre [(nat-int? n)]}
   (case n
     0 (list [])
@@ -697,5 +698,15 @@
    :cljs
    (defn make-js-value [x] x))
 
+#?(:clj
+   (defmacro val-op
+     {:private true}
+     [x]
+     (try
+       (let [c (Class/forName "cljs.tagged_literals.JSValue")]
+         `(.val ^"cljs.tagged_literals.JSValue" ~x))
+       (catch ClassNotFoundException _
+         `(.val ~x)))))
+
 (defn val-of-js-value [x]
-  (if (js-value? x) (.val x) x))
+  (if (js-value? x) (val-op x) x))


### PR DESCRIPTION
Addresses all reflection warnings by adding type hints, or marking defns that appeared to only target cljs as such

I verified that reflection count decreases to zero with `lein check`.