### PR TITLE
CI: exercise JVM variant, with clojurescript being present in the classpath

### DIFF
--- a/.github/workflows/meander.yml
+++ b/.github/workflows/meander.yml
@@ -3,7 +3,7 @@ name: Meander CI
 on: [push]
 
 jobs:
-  clojure:
+  jvm-clj:
 
     runs-on: ubuntu-latest
     
@@ -12,10 +12,22 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - name: Run tests
+    - name: Run JVM tests
       run: clojure -A:test
 
-  clojurescript:
+  jvm-clj-and-cljs-in-cp:
+
+    runs-on: ubuntu-latest
+    
+    container:
+      image:  clojure:openjdk-11-tools-deps
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run JVM tests, with clojurescript being in the classpath
+      run: clojure -A:cljs:test
+
+  cljs:
 
     runs-on: ubuntu-latest
     
@@ -24,5 +36,5 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - name: Run tests
-      run: clojure -A:cljs-test
+    - name: Run cljs tests
+      run: clojure -A:cljs:cljs-test

--- a/bin/test
+++ b/bin/test
@@ -32,7 +32,7 @@ function cljs-test () {
   echo 'Running ClojureScript tests'
   color default
   echo '---------------------------'
-  clojure -A:cljs-test
+  clojure -A:cljs:cljs-test
 }
 
 case $1 in

--- a/deps.edn
+++ b/deps.edn
@@ -10,9 +10,9 @@
                                eftest/eftest {:mvn/version "0.5.8"}}
                   :main-opts ["-e" "(require,'[eftest.runner,:refer,[find-tests,run-tests]])"
                               "-e" "(run-tests,(find-tests,\"test\"))"]}
+           :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.439"}}}
            :cljs-test {:extra-paths ["test"]
                        :extra-deps {org.clojure/test.check {:mvn/version "0.10.0-alpha3"}
-                                    org.clojure/clojurescript {:mvn/version "1.10.439"}
                                     olical/cljs-test-runner {:mvn/version "3.4.0"}}
                        :main-opts ["-m" "cljs-test-runner.main"]}
            :make-defproject {:extra-paths ["bin"]

--- a/src/meander/util/epsilon.cljc
+++ b/src/meander/util/epsilon.cljc
@@ -7,6 +7,7 @@
                                __dissoc
                                __nth]])))
 
+#?(:clj (set! *warn-on-reflection* true))
 
 (defn cljs-env?
   "true if compiling ClojureScript or in a ClojureScript setting,
@@ -703,10 +704,11 @@
      {:private true}
      [x]
      (try
-       (let [c (Class/forName "cljs.tagged_literals.JSValue")]
-         `(.val ^"cljs.tagged_literals.JSValue" ~x))
+       (Class/forName "cljs.tagged_literals.JSValue")
+       `(.val ^"cljs.tagged_literals.JSValue" ~x)
        (catch ClassNotFoundException _
          `(.val ~x)))))
 
-(defn val-of-js-value [x]
-  (if (js-value? x) (val-op x) x))
+#?(:clj
+   (defn val-of-js-value [x]
+     (if (js-value? x) (val-op x) x)))


### PR DESCRIPTION
> See: https://github.com/noprompt/meander/pull/172#issuecomment-812314943

This way we ensure that the following:

```clj
(defmacro val-op
  {:private true}
  [x]
  (try
    (let [c (Class/forName "cljs.tagged_literals.JSValue")]
      `(.val ^"cljs.tagged_literals.JSValue" ~x))
    (catch ClassNotFoundException _
      `(.val ~x))))
```

...doesn't cause an issue in either branch of the `try/catch`.