### PR TITLE
Change "Zero or more" example to improve clarity.

### DIFF
--- a/doc/operator-overview.md
+++ b/doc/operator-overview.md
@@ -567,8 +567,8 @@ The `...` postfix operator matches the _subsequence_ of patterns to its left (up
 ```
 
 ```clj
-(m/match [:A :A :A :B :A :C :A :D]
-  [:A !xs ...]
+(m/match [:Z :A :Z :B :Z :C :Z :D]
+  [:Z !xs ...]
   !xs)
 ;; =>
 [:A :B :C :D]


### PR DESCRIPTION
This is subjective; I was confused reading this example because I saw `:A` repeated and I couldn't figure out what was happening.