### PR TITLE
Allow type checks and bound checks to be disabled

### DIFF
--- a/src/meander/environment/epsilon.cljc
+++ b/src/meander/environment/epsilon.cljc
@@ -4,14 +4,16 @@
   {:meander.epsilon/abstract-disjunction true
    ;; This reduces code size at the expensive of performance.
    :meander.epsilon/abstract-plus false
-   ;; When true enables bounds checking.
-   :meander.epsilon/bounds-check true
    :meander.epsilon/eliminate-double-negation true
    :meander.epsilon/flatten-and true
    :meander.epsilon/flatten-or true
    :meander.epsilon/infer-case true
    :meander.epsilon/infer-literal-seq true
    :meander.epsilon/infer-literal-vector true
+   ;; When set to true disables type checking.
+   :meander.epsilon/no-type-check false
+   ;; When set to true disables bounds checking.
+   :meander.epsilon/no-bounds-check false
    :meander.epsilon/prioritize-map-entries true
    :meander.epsilon/prioritize-literal-set-elements false
    ;; This is false because enabling it offers no significant
@@ -32,8 +34,6 @@
    :meander.epsilon/rewrite-set-rest-to-disj false
    :meander.epsilon/rewrite-vector-as-to-and true
    :meander.epsilon/substitute-acyclic-references true
-   ;; When set to true enables type checking.
-   :meander.epsilon/type-check true
    ;; When set to true disables type checks and bounds checks.
    :meander.epsilon/unsafe false
    :meander.syntax.epsilon/expander-registry {}

--- a/src/meander/environment/epsilon.cljc
+++ b/src/meander/environment/epsilon.cljc
@@ -4,6 +4,8 @@
   {:meander.epsilon/abstract-disjunction true
    ;; This reduces code size at the expensive of performance.
    :meander.epsilon/abstract-plus false
+   ;; When true enables bounds checking.
+   :meander.epsilon/bounds-check true
    :meander.epsilon/eliminate-double-negation true
    :meander.epsilon/flatten-and true
    :meander.epsilon/flatten-or true
@@ -30,6 +32,11 @@
    :meander.epsilon/rewrite-set-rest-to-disj false
    :meander.epsilon/rewrite-vector-as-to-and true
    :meander.epsilon/substitute-acyclic-references true
+   ;; When set to true enables type checking.
+   :meander.epsilon/type-check true
+   ;; When set to true disables type checks and bounds checks.
+   :meander.epsilon/unsafe false
    :meander.syntax.epsilon/expander-registry {}
    :meander.syntax.epsilon/phase nil
    :meander.syntax.epsilon/parser-registry {}})
+

--- a/src/meander/epsilon.clj
+++ b/src/meander/epsilon.clj
@@ -29,8 +29,20 @@
   match successfully an error will be thrown indicating the pattern
   match failed.
 
-  This operator restricts ambiguous patterns i.e. patterns which have
-  more than one possible match. For example, the pattern
+  Optionally, type checks and/or bounds checks can be omitted from
+  compiled code by annotating the `match` macro form with meta data.
+
+    ;; Disable runtime type checking.
+    ^::no-type-check (match ,,,)
+
+    ;; Disable runtime bounds checking of sequences.
+    ^::no-bounds-check (match ,,,)
+
+    ;; Disable both runtime type checking and bounds checking.
+    ^::unsafe (match ,,,)
+
+  Note: This operator restricts ambiguous patterns i.e. patterns which
+  have more than one possible match. For example, the pattern
 
       #{?x ?y}
 
@@ -61,6 +73,18 @@
         pattern_1 expr_1
         ,,,
         pattern_n expr_n)
+
+  Optionally, type checks and/or bounds checks can be omitted from
+  compiled code by annotating the `find` macro form with meta data.
+
+    ;; Disable runtime type checking.
+    ^::no-type-check (find ,,,)
+
+    ;; Disable runtime bounds checking of sequences.
+    ^::no-bounds-check (find ,,,)
+
+    ;; Disable both runtime type checking and bounds checking.
+    ^::unsafe (find ,,,)
   "
   {:style/indent :defn}
   [x & clauses]
@@ -78,6 +102,18 @@
         pattern_1 expr_1
         ,,,
         pattern_n expr_n)
+
+  Optionally, type checks and/or bounds checks can be omitted from
+  compiled code by annotating the `search` macro form with meta data.
+
+    ;; Disable runtime type checking.
+    ^::no-type-check (search ,,,)
+
+    ;; Disable runtime bounds checking of sequences.
+    ^::no-bounds-check (search ,,,)
+
+    ;; Disable both runtime type checking and bounds checking.
+    ^::unsafe (search ,,,)
 
   Example:
 

--- a/src/meander/match/ir/epsilon.cljc
+++ b/src/meander/match/ir/epsilon.cljc
@@ -42,14 +42,16 @@ compilation decisions."
 (defn bounds-check?
   {:private true}
   []
-  (or (not (unsafe?))
-      (not (:meander.epsilon/no-bounds-check *env*))))
+  (if (unsafe?)
+    false
+    (not (:meander.epsilon/no-bounds-check *env*))))
 
 (defn type-check?
   {:private true}
   []
-  (or (not (unsafe?))
-      (not (:meander.epsilon/no-type-check *env*))))
+  (if (unsafe?)
+    false
+    (not (:meander.epsilon/no-type-check *env*))))
 
 (defn breadth-first?
   "`true` if the current IR compilation environment `*env*` specifies

--- a/src/meander/match/ir/epsilon.cljc
+++ b/src/meander/match/ir/epsilon.cljc
@@ -36,26 +36,20 @@ compilation decisions."
 
 (defn unsafe?
   {:private true}
-  ([] (true? (:meander.epsilon/unsafe *env*)))
-  ([env] (true? (:meander.epsilon/unsafe env))))
+  []
+  (boolean (:meander.epsilon/unsafe *env*)))
 
 (defn bounds-check?
   {:private true}
-  ([]
-   (or (false? (unsafe?))
-       (false? (:meander.epsilon/no-bounds-check *env*))))
-  ([env]
-   (or (false? (unsafe?))
-       (false? (:meander.epsilon/no-bounds-check env)))))
+  []
+  (or (not (unsafe?))
+      (not (:meander.epsilon/no-bounds-check *env*))))
 
 (defn type-check?
   {:private true}
-  ([]
-   (or (false? (unsafe?))
-       (false? (:meander.epsilon/no-type-check *env*))))
-  ([env]
-   (or (false? (unsafe?))
-       (false? (:meander.epsilon/no-type-check env)))))
+  []
+  (or (not (unsafe?))
+      (not (:meander.epsilon/no-type-check *env*))))
 
 (defn breadth-first?
   "`true` if the current IR compilation environment `*env*` specifies

--- a/src/meander/match/ir/epsilon.cljc
+++ b/src/meander/match/ir/epsilon.cljc
@@ -1464,12 +1464,12 @@ compilation decisions."
 (defmethod compile* :lookup
   [ir fail kind]
   (if (or (r.util/cljs-env? *env*)
-          (type-check?))
+          (not (type-check?)))
+    `(get ~(compile* (:target ir) fail kind)
+          ~(compile* (:key ir) fail kind))
     `(.valAt ~(with-meta (compile* (:target ir) fail kind)
                 {:tag 'clojure.lang.ILookup})
-             ~(compile* (:key ir) fail kind))
-    `(get ~(compile* (:target ir) fail kind)
-          ~(compile* (:key ir) fail kind))))
+             ~(compile* (:key ir) fail kind))))
 
 (defmethod compile* :lvr-bind
   [ir fail kind]

--- a/src/meander/match/ir/epsilon.cljc
+++ b/src/meander/match/ir/epsilon.cljc
@@ -1004,14 +1004,14 @@ compilation decisions."
   {:private true}
   [env node]
   (if (bounds-check?)
-    node
     (case (op node)
       :nth
       (let [target-type (lookup-type env (:form (:target node)))]
         (if (isa? target-type VectorInterface)
           (op-eval `(~(:form (:target node)) ~(:index node)))
           node))
-      node)))
+      node)
+    node))
 
 (defn rewrite-with-types
   {:private true}
@@ -1326,7 +1326,6 @@ compilation decisions."
   [ir fail kind]
   (let [then (compile* (:then ir) fail kind)]
     (if (bounds-check?)
-      then
       (let [length (:length ir)
             target (compile* (:target ir) fail kind)
             test (case (:kind ir)
@@ -1344,7 +1343,8 @@ compilation decisions."
                    `(= (count ~target) ~length))]
         `(if ~test
            ~then
-           ~fail)))))
+           ~fail))
+      then)))
 
 (defmethod compile* :check-equal
   [ir fail kind]
@@ -1482,8 +1482,8 @@ compilation decisions."
   (let [target (compile* (:target ir) fail kind)
         index (:index ir)]
     (if (bounds-check?)
-      `(nth ~target ~index nil)
-      `(nth ~target ~index))))
+      `(nth ~target ~index)
+      `(nth ~target ~index nil))))
 
 (defmethod compile* :mut-bind
   [ir fail kind]


### PR DESCRIPTION
This patch allows the programmer to disable type checking and bounds checking through meta data on a `match`, `find`, `search`, etc. form.

Disable both type and bounds checking
```clj
^::m/unsafe (m/match ,,,)
```

Disable only type checking
```clj
^::m/no-type-check (m/match ,,,)
```

Disable only bounds checking
```clj
^::m/no-bounds-check (m/match ,,,)
```