### PR TITLE
Allow more than one rest pattern (& pattern) to appear in supported patterns

### DIFF
--- a/src/meander/substitute/epsilon.cljc
+++ b/src/meander/substitute/epsilon.cljc
@@ -218,6 +218,7 @@
   [node env]
   [(:symbol node) env])
 
+
 (defmethod compile* :map
   [node env]
   (let [[form env] (if-some [as-node (:as node)]
@@ -229,7 +230,7 @@
         [form env] (if-some [rest-node (:rest-map node)]
                      (let [[rest-form env] (compile* rest-node env)]
                        [`(let [form# ~form]
-                           (merge (into {} ~rest-form) form#)) env])
+                           (merge ~rest-form form#)) env])
                      [form env])
         ;; Search for keys containing memory variables that have
         ;; associated iterator symbols in the environment.
@@ -246,6 +247,11 @@
                   {})
                form)]
     [form env]))
+
+(defmethod compile* :merge
+  [node env]
+  (let [[forms env*] (compile-all* (:patterns node) env)]
+    [`(merge ~@(map (fn [form] `(into {} ~form)) forms)) env*]))
 
 (defmethod compile* :mvr
   [node env]

--- a/src/meander/substitute/epsilon.cljc
+++ b/src/meander/substitute/epsilon.cljc
@@ -252,7 +252,7 @@
 (defmethod compile* :merge
   [node env]
   (let [[forms env*] (compile-all* (:patterns node) env)]
-    [`(merge ~@(map (fn [form] `(into {} ~form)) forms)) env*]))
+    [`(into {} cat [~@forms]) env*]))
 
 (defmethod compile* :mvr
   [node env]

--- a/src/meander/substitute/epsilon.cljc
+++ b/src/meander/substitute/epsilon.cljc
@@ -230,7 +230,8 @@
         [form env] (if-some [rest-node (:rest-map node)]
                      (let [[rest-form env] (compile* rest-node env)]
                        [`(let [form# ~form]
-                           (merge ~rest-form form#)) env])
+                           (merge ~rest-form form#))
+                        env])
                      [form env])
         ;; Search for keys containing memory variables that have
         ;; associated iterator symbols in the environment.

--- a/src/meander/syntax/epsilon.cljc
+++ b/src/meander/syntax/epsilon.cljc
@@ -360,11 +360,14 @@
         (case tag
           :amp
           (if-some [[rest-node & r*] (next r)]
-            {:tag :prt
-             :left {:tag :cat, :elements l}
-             :right {:tag :prt
-                     :left {:tag :tail, :pattern rest-node}
-                     :right (expand-prt r*)}}
+            (let [left-node (if (any-node? rest-node)
+                              {:tag :drp}
+                              {:tag :tail, :pattern rest-node})]
+              {:tag :prt
+               :left {:tag :cat, :elements l}
+               :right {:tag :prt
+                       :left left-node
+                       :right (expand-prt r*)}})
             {:tag :cat, :elements l})
 
           ;; else
@@ -422,10 +425,13 @@
           (case tag
             :amp
             (if-some [[rest-node & r*] (next r)]
-              {:tag :prt
-               :left {:tag :tail, :pattern rest-node}
-               :right (expand-prt r*)}
-              {:tag :tail, :pattern {:tag :any}})
+              (let [left-node (if (any-node? rest-node)
+                                {:tag :drp}
+                                {:tag :tail, :pattern rest-node})]
+                {:tag :prt
+                 :left left-node
+                 :right (expand-prt r*)})
+              {:tag :drp})
 
             ;; else
             {:tag :prt

--- a/src/meander/util/epsilon.cljc
+++ b/src/meander/util/epsilon.cljc
@@ -454,6 +454,50 @@
           (repeat b)))))
      (range (inc (.length str))))))
 
+(defn increment-code
+  {:private true}
+  [base code]
+  (reduce
+   (fn [v i]
+     (let [b (nth v i)]
+       (if (zero? b)
+         (reduced (assoc v i 1))
+         (let [b (+ b 1)]
+           (if (zero? (mod b base))
+             (assoc v i 0)
+             (assoc v i b))))))
+   code
+   (range (count code))))
+
+(defn code-seq
+  {:arglists '([number-of-positions number-of-partitions])
+   :private true}
+  [n m]
+  (let [number-of-answers (Math/pow m n)]
+    (if (< number-of-answers ##Inf)
+      (take number-of-answers
+            (iterate (partial increment-code m) (vec (repeat n 0))))
+      (let [last-answer (vec (repeat n (dec m)))]
+        (take-while (fn [answer]
+                      (not (= answer last-answer)))
+                    (iterate (partial increment-code m) (vec (repeat n 0))))))))
+
+
+(defn map-partitions
+  {:arglists '([map number-of-partitions])}
+  [m n]
+  (let [elements (vec m)
+        number-of-elements (count m)
+        empty-partitions (vec (repeat n {}))]
+    (map (fn [code]
+           (reduce (fn [partitions i]
+                     (update partitions (nth code i) conj (nth elements i)))
+                   empty-partitions
+                   (range (count code))))
+         (code-seq number-of-elements n))))
+
+(doall (map-partitions {:a 1 :b 2 :c 3} 3))
+
 
 (defn partitions "
   Examples:

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -2204,8 +2204,14 @@
     (let [?rest {:foo "bar" :baz "quux" :quux "ducks"}
           ?as {:foo "goo" :frob "knob"}]
       (t/is (= {:foo "quux" :baz "bar" :quux "ducks" :frob "knob"}
-               (r/subst {:foo "quux" :baz "bar" & ?rest :as ?as}))))))
+               (r/subst {:foo "quux" :baz "bar" & ?rest :as ?as})))))
 
+  (t/testing "multiple rest maps"
+    (let [?m1 {:a 1 :b 2}
+          ?m2 {:c 3 :d 4}
+          ?kvs1 [[:e 5] [:f 6]]]
+      (t/is (= {:a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8 :i 9}
+               (r/subst {&1 ?m1 &2 ?m2 &3 ?kvs1 &4 [[:g 7] [:h 8] [:i 9]]}))))))
 
 (t/deftest subst-$-test
   (let [?context (fn [hole]

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -293,6 +293,44 @@
                [?x ?y]
                _ false)))))
 
+
+(t/deftest seq-multiple-rest
+  (let [x 'x
+        y 'y
+        z 'z]
+    (let [l1 '(x y x y)]
+      (t/is (= '[() (x y x y)]
+               (r/find l1 (& ?1 & ?2) [?1 ?2])))
+
+      (t/is (= '[[() (x y x y)]
+                 [(x) (y x y)]
+                 [(x y) (x y)]
+                 [(x y x) (y)]
+                 [(x y x y) ()]]
+               (r/search l1 (& ?1 & ?2) [?1 ?2]))))
+
+    (let [l2 '(x y z x y)]
+      (t/is (= '[(x y) (x y)]
+               (r/find l2 (& ?1 z & ?2) [?1 ?2])))
+
+      (t/is (= '[[(x y) (x y)]]
+               (r/search l2 (& ?1 z & ?2) [?1 ?2]))))
+
+    (let [l3 '(x y z x z y)]
+      (t/is (= '[(x y) (x z y)]
+               (r/find l3 (& ?1 z & ?2) [?1 ?2])))
+
+      (t/is (= '[[(x y) (x z y)]
+                 [(x y z x) (y)]]
+               (r/search l3 (& ?1 z & ?2) [?1 ?2]))))
+
+    (let [l4 '(1 2 3 4)]
+      (t/is (= '(3 4 1)
+               (r/rewrite l4 (& ?1 2 & ?2) (& ?2 & ?1))))
+
+      (t/is (= '[(1 2 3 4) (2 3 4 1) (3 4 1 2) (4 1 2 3) (1 2 3 4)]
+               (r/rewrites l4 (& ?1 & ?2) (& ?2 & ?1)))))))
+
 ;;; Vectors
 
 
@@ -478,6 +516,44 @@
 
   (t/is (= '(1)
            (r/search '[1 1 1 1 1] [1 ..4 ?x] ?x))))
+
+(t/deftest vec-multiple-rest
+  (let [x 'x
+        y 'y
+        z 'z]
+    (let [v1 '[x y x y]]
+      (t/is (= '[[] [x y x y]]
+               (r/find v1 [& ?1 & ?2] [?1 ?2])))
+
+      (t/is (= '[[[] [x y x y]]
+                 [[x] [y x y]]
+                 [[x y] [x y]]
+                 [[x y x] [y]]
+                 [[x y x y] []]]
+               (r/search v1 [& ?1 & ?2] [?1 ?2]))))
+
+    (let [v2 '[x y z x y]]
+      (t/is (= '[[x y] [x y]]
+               (r/find v2 [& ?1 z & ?2] [?1 ?2])))
+
+      (t/is (= '[[[x y] [x y]]]
+               (r/search v2 [& ?1 z & ?2] [?1 ?2]))))
+
+    (let [v3 '[x y z x z y]]
+      (t/is (= '[[x y] [x z y]]
+               (r/find v3 [& ?1 z & ?2] [?1 ?2])))
+
+      (t/is (= '[[[x y] [x z y]]
+                 [[x y z x] [y]]]
+               (r/search v3 [& ?1 z & ?2] [?1 ?2]))))
+
+    (let [v4 [1 2 3 4]]
+      (t/is (= [3 4 1]
+               (r/rewrite v4 [& ?1 2 & ?2] [& ?2 & ?1])))
+
+      (t/is (= [[1 2 3 4] [2 3 4 1] [3 4 1 2] [4 1 2 3] [1 2 3 4]]
+               (r/rewrites v4 [& ?1 & ?2] [& ?2 & ?1]))))))
+
 
 ;; Maps
 

--- a/test/meander/epsilon_test.cljc
+++ b/test/meander/epsilon_test.cljc
@@ -2675,3 +2675,15 @@
                {?e {:name "Ivan", :friend (r/or (r/scan [?t ?f]) [?t ?f])},
                 ?f {:name ?name}}
                [?e ?t ?f ?name])))))
+
+(t/deftest semantic-equivalence-of-&-any-and-drop-test
+  (t/is (= ' ([1 2 10]
+              [1 3 10]
+              [1 4 10]
+              [1 5 10]
+              [1 6 10]
+              [1 7 10]
+              [1 8 10]
+              [1 9 10])
+             (r/search (range 1 11) (?a . _ ... ?b . _ ... ?c) [?a ?b ?c])
+             (r/search (range 1 11) (?a & _ ?b & _ ?c) [?a ?b ?c]))))


### PR DESCRIPTION
This patch permits sequential patterns to use more than one rest pattern enabling the following possibilities (among many more).

Seq pattern matching

```clj
(m/find (range 1 11)
  (1 2 & ?rest-1 4 5 & ?rest-2 9 10)
  [?rest-1 ?rest-2])
;; => [(3) (6 7 8)]
```
Seq pattern matching with vector pattern substitution

```clj
(m/rewrite (range 1 11)
  (1 2 & ?rest-1 4 5 & ?rest-2 9 10)
  [& ?rest-2 :A :B :C & ?rest-1])
;; => [6 7 8 :A :B :C 3]
```

Map matching

```clj
(let [m {:a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8 :i 9}]
  (m/find m
    {:g 7 :h 8 :i 9
     &a {?k (m/pred even?) & '{} :as ?m1}
     &b ?m2}
    [?k ?m1 ?m2]))
;; =>
[:f {:f 6} {:e 5, :c 3, :b 2, :d 4, :a 1}]
```

Map substitution

```clj
(let [?m1 {:a 1 :b 2}
      ?m2 {:c 3 :d 4}
      ?kvs1 [[:e 5] [:f 6]]]
  (m/subst {&1 ?m1
            &2 ?m2
            &3 ?kvs1
            &4 [[:g 7] [:h 8] [:i 9]]}))
;; =>
{:a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8 :i 9}
```
Whats new on the surface is slight change in syntax: the rest operator is a symbol with a name matching the regex `&.*`. This is to get around the limitation of duplicate map keys.

In terms of implementation, there is a new node type `:merge` which is created during map parsing.