### PR TITLE
reflection warning in epsilon util, fixes #230

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pom.xml.asc
 cljs-test-runner-out/
 nashorn_code_cache/
 /bin/release/
+.cache
+.calva

--- a/src/meander/util/epsilon.cljc
+++ b/src/meander/util/epsilon.cljc
@@ -5,7 +5,11 @@
      (:require-macros [meander.util.epsilon
                        :refer [__disj
                                __dissoc
-                               __nth]])))
+                               __nth]]))
+  (:import #?(:bb  ()
+              :clj (cljs.tagged_literals JSValue))))
+
+#?(:clj (set! *warn-on-reflection* true))
 
 (defn cljs-env?
   "true if compiling ClojureScript or in a ClojureScript setting,
@@ -717,40 +721,26 @@
                    (symbol (name (:name cljs-ns)) (name sym)))))
              sym)))
 
-#?(:clj
-   (try
-     (let [c (Class/forName "cljs.tagged_literals.JSValue")]
-       (defn js-value? [x]
-         (instance? c x)))
-     (catch ClassNotFoundException _
-       (defn js-value? [x]
-         false)))
+#?(:bb
+   (defn js-value? [_x] false)
+   :clj
+   (defn js-value? [x] (instance? JSValue x))
    :cljs
-   (defn js-value? [x]
-     false))
+   (defn js-value? [_x] false))
 
-#?(:clj
-   (try
-     (let [c (Class/forName "cljs.tagged_literals.JSValue")
-           s 'cljs.tagged_literals.JSValue]
-       (defn make-js-value [x]
-         (eval `(new ~s ~x))))
-     (catch ClassNotFoundException _
-       (defn make-js-value [x]
-         x)))
+#?(:bb
+   (defn make-js-value [x] x)
+   :clj
+   (defn make-js-value [x] (new JSValue x))
    :cljs
    (defn make-js-value [x] x))
 
-#?(:clj
-   (defmacro val-op
-     {:private true}
-     [x]
-     (try
-       (Class/forName "cljs.tagged_literals.JSValue")
-       `(.val ^"cljs.tagged_literals.JSValue" ~x)
-       (catch ClassNotFoundException _
-         `(.val ~x)))))
-
-#?(:clj
+#?(:bb
+   (defn val-of-js-value [x] x)
+   :clj
    (defn val-of-js-value [x]
-     (if (js-value? x) (val-op x) x)))
+     (if (js-value? x)
+       (.-val ^JSValue x)
+       x))
+   :cljs
+   (defn val-of-js-value [x] x))


### PR DESCRIPTION
Just wanted to first say thank you for your hard work on this library. I started playing around with it today and it's awesome!

Fixed issue with reflection warning reported in #230.
I added `bb` reader conditionals before the `clj` ones which prevent us from trying to dynamically load the class.
[Babashka Reader conditionals](https://book.babashka.org/#_reader_conditionals) will read `bb` before `clj`.

I added cache in gitignore which clj-kondo & lsp-lisp use and is safe to ignore.
I added calva in gitignore for anyone who codes using calva on VSCode.

Please let me know if you have any questions or you want me to make any changes.