### PR TITLE
fix reflection warning without breaking ability to load meander.util.epsilon without clojurescript on classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ nashorn_code_cache/
 /bin/release/
 .cache
 .calva
+.idea/
+*.iml


### PR DESCRIPTION
https://github.com/noprompt/meander/pull/237 broke the ability to load this namespace without ClojureScript on the classpath. This change reverts that update and fixes the reflection warning while remaining usable without ClojureScript.